### PR TITLE
Add link to Grid Garden game in 'Interactive'

### DIFF
--- a/badges-active/css/_micro_css-current.md
+++ b/badges-active/css/_micro_css-current.md
@@ -39,6 +39,7 @@ Choose one:
 
 ### Interactive
 
+- [Grid Garden](http://cssgridgarden.com/)
 - [CSS Diner](http://flukeout.github.io/)
 - [Flexbox Froggy](http://flexboxfroggy.com/)
 - [Flexbox Defense](http://www.flexboxdefense.com/)


### PR DESCRIPTION
Add link to Grid Garden game in 'Interactive' section of CSS Current Micro Badge.