### PR TITLE
[JS Master] update current masters list

### DIFF
--- a/badges-active/javascript/master.md
+++ b/badges-active/javascript/master.md
@@ -36,6 +36,7 @@
 
 ## Current JavaScript Masters:
 
+- [Kyle West](https://github.com/kyle-west)
 
 -----
 


### PR DESCRIPTION
I presented on my project this morning. Now I want to make my name available to mentor others on their projects.

See: https://docs.google.com/spreadsheets/d/12t2vEf-jQuEyX3SPgkZbIN5oPoVpcXExcBLEz9hs7yo/edit#gid=0&range=N50

I did not see anyone else listed as a master, which shocks me - otherwise I would have added them to the list too.